### PR TITLE
Added modifier and showUi parameters

### DIFF
--- a/kscan/src/androidMain/kotlin/org/ncgroup/kscan/ScannerView.android.kt
+++ b/kscan/src/androidMain/kotlin/org/ncgroup/kscan/ScannerView.android.kt
@@ -30,8 +30,10 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 actual fun ScannerView(
+    modifier: Modifier,
     codeTypes: List<BarcodeFormat>,
     colors: ScannerColors,
+    showUi: Boolean,
     result: (BarcodeResult) -> Unit,
 ) {
     val context = LocalContext.current
@@ -71,7 +73,7 @@ actual fun ScannerView(
     }
 
     Box(
-        modifier = Modifier.fillMaxSize(),
+        modifier = modifier,
     ) {
         AndroidView(
             modifier = Modifier.fillMaxSize(),
@@ -130,32 +132,34 @@ actual fun ScannerView(
             },
         )
 
-        ScannerUI(
-            onCancel = { result(BarcodeResult.OnCanceled) },
-            torchEnabled = torchEnabled,
-            onTorchEnabled = { cameraControl?.enableTorch(it) },
-            zoomRatio = zoomRatio,
-            zoomRatioOnChange = { ratio ->
-                cameraControl?.setZoomRatio(ratio)
-            },
-            maxZoomRatio = maxZoomRatio,
-            colors = colors,
-        )
-
-        if (showBottomSheet) {
-            ScannerBarcodeSelectionBottomSheet(
-                barcodes = barcodes.toList(),
-                sheetState = sheetState,
-                onDismissRequest = {
-                    showBottomSheet = false
-                    barcodes.clear()
+        if(showUi) {
+            ScannerUI(
+                onCancel = { result(BarcodeResult.OnCanceled) },
+                torchEnabled = torchEnabled,
+                onTorchEnabled = { cameraControl?.enableTorch(it) },
+                zoomRatio = zoomRatio,
+                zoomRatioOnChange = { ratio ->
+                    cameraControl?.setZoomRatio(ratio)
                 },
-                result = {
-                    result(it)
-                    showBottomSheet = false
-                    barcodes.clear()
-                },
+                maxZoomRatio = maxZoomRatio,
+                colors = colors,
             )
+
+            if (showBottomSheet) {
+                ScannerBarcodeSelectionBottomSheet(
+                    barcodes = barcodes.toList(),
+                    sheetState = sheetState,
+                    onDismissRequest = {
+                        showBottomSheet = false
+                        barcodes.clear()
+                    },
+                    result = {
+                        result(it)
+                        showBottomSheet = false
+                        barcodes.clear()
+                    },
+                )
+            }
         }
     }
 

--- a/kscan/src/commonMain/kotlin/org/ncgroup/kscan/ScannerView.kt
+++ b/kscan/src/commonMain/kotlin/org/ncgroup/kscan/ScannerView.kt
@@ -1,10 +1,14 @@
 package org.ncgroup.kscan
 
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 
 @Composable
 expect fun ScannerView(
+    modifier: Modifier = Modifier.fillMaxSize(),
     codeTypes: List<BarcodeFormat>,
     colors: ScannerColors = scannerColors(),
+    showUi: Boolean = true,
     result: (BarcodeResult) -> Unit,
 )

--- a/kscan/src/desktopMain/kotlin/org/ncgroup/kscan/ScannerView.desktop.kt
+++ b/kscan/src/desktopMain/kotlin/org/ncgroup/kscan/ScannerView.desktop.kt
@@ -1,10 +1,13 @@
 package org.ncgroup.kscan
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 
 @Composable
 actual fun ScannerView(
+    modifier: Modifier,
     codeTypes: List<BarcodeFormat>,
     colors: ScannerColors,
+    showUi: Boolean,
     result: (BarcodeResult) -> Unit,
 ) {}

--- a/kscan/src/wasmJsMain/kotlin/org/ncgroup/kscan/ScannerView.wasmJs.kt
+++ b/kscan/src/wasmJsMain/kotlin/org/ncgroup/kscan/ScannerView.wasmJs.kt
@@ -1,10 +1,13 @@
 package org.ncgroup.kscan
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 
 @Composable
 actual fun ScannerView(
+    modifier: Modifier,
     codeTypes: List<BarcodeFormat>,
     colors: ScannerColors,
+    showUi: Boolean,
     result: (BarcodeResult) -> Unit,
 ) {}


### PR DESCRIPTION
Adding the ability to hide the UI and pass in a modifier. This will allow users to adapt KScan into their UI rather than use the provided one. The provided UI is good, but being able to turn it off and us KScan as a raw scanner is incredible useful.

```kotlin
if (showScanner) {
                ScannerView(
                    modifier = Modifier.width(350.dp).height(350.dp),
                    showUi = false,
                    codeTypes =
                        listOf(
                            BarcodeFormat.FORMAT_ALL_FORMATS,
                            BarcodeFormat.TYPE_GEO,
                        ),
                ) { result ->
                    when (result) {
                        is BarcodeResult.OnSuccess -> {
                            barcode = result.barcode.data
                            format = result.barcode.format
                            showScanner = false
                        }
                        is BarcodeResult.OnFailed -> {
                            result.exception.printStackTrace()
                            showScanner = false
                        }
                        BarcodeResult.OnCanceled -> {
                            showScanner = false
                        }
                    }
                }
            }
```

![Screenshot 2025-04-01 214748](https://github.com/user-attachments/assets/cc3be499-0022-46c1-9cca-c8e2c4156995)
