### PR TITLE
Fix orientation

### DIFF
--- a/kscan/src/iosMain/kotlin/org/ncgroup/kscan/CameraViewController.kt
+++ b/kscan/src/iosMain/kotlin/org/ncgroup/kscan/CameraViewController.kt
@@ -23,7 +23,18 @@ import platform.AVFoundation.AVMetadataObjectTypePDF417Code
 import platform.AVFoundation.AVMetadataObjectTypeQRCode
 import platform.AVFoundation.AVMetadataObjectTypeUPCECode
 import platform.AVFoundation.videoZoomFactor
+import platform.AVFoundation.AVCaptureVideoOrientation
+import platform.AVFoundation.AVCaptureVideoOrientationLandscapeLeft
+import platform.AVFoundation.AVCaptureVideoOrientationLandscapeRight
+import platform.AVFoundation.AVCaptureVideoOrientationPortrait
+import platform.AVFoundation.AVCaptureVideoOrientationPortraitUpsideDown
 import platform.UIKit.UIColor
+import platform.UIKit.UIApplication
+import platform.UIKit.UIInterfaceOrientation
+import platform.UIKit.UIInterfaceOrientationLandscapeLeft
+import platform.UIKit.UIInterfaceOrientationLandscapeRight
+import platform.UIKit.UIInterfaceOrientationPortrait
+import platform.UIKit.UIInterfaceOrientationPortraitUpsideDown
 import platform.UIKit.UIViewController
 import platform.darwin.dispatch_get_main_queue
 
@@ -99,6 +110,7 @@ class CameraViewController(
         previewLayer.frame = view.layer.bounds
         previewLayer.videoGravity = AVLayerVideoGravityResizeAspectFill
         view.layer.addSublayer(previewLayer)
+        updatePreviewOrientation()
     }
 
     override fun viewWillAppear(animated: Boolean) {
@@ -119,6 +131,7 @@ class CameraViewController(
     override fun viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         previewLayer.frame = view.layer.bounds
+        updatePreviewOrientation()
     }
 
     override fun captureOutput(
@@ -193,6 +206,21 @@ class CameraViewController(
         }
         val appFormat = AV_TO_APP_FORMAT_MAP[type] ?: return false
         return codeTypes.contains(appFormat)
+    }
+
+    private fun updatePreviewOrientation() {
+        if (!::previewLayer.isInitialized) return
+        val connection = previewLayer.connection ?: return
+        // Map the current UI interface orientation to AVCapture orientation
+        val uiOrientation: UIInterfaceOrientation = UIApplication.sharedApplication().statusBarOrientation
+        val videoOrientation: AVCaptureVideoOrientation = when (uiOrientation) {
+            UIInterfaceOrientationLandscapeLeft -> AVCaptureVideoOrientationLandscapeLeft
+            UIInterfaceOrientationLandscapeRight -> AVCaptureVideoOrientationLandscapeRight
+            UIInterfaceOrientationPortraitUpsideDown -> AVCaptureVideoOrientationPortraitUpsideDown
+            else -> AVCaptureVideoOrientationPortrait
+        }
+        // Set the preview connection orientation (use property setter in Kotlin/Native)
+        connection.videoOrientation = videoOrientation
     }
 
     private fun AVMetadataObjectType.toFormat(): BarcodeFormat {


### PR DESCRIPTION
This fixes https://github.com/ismai117/KScan/issues/17
- Did not see any tests in the project, so no tests updated
- Not sure if this issue only appears on iPadOS 26, I was not able to get a physical device with iPadOS 18 

To test the fix, you can comment out all the lines in `updatePreviewOrientation`:
- Grab iPad with iPadOS 26
- Launch the app in Landscape mode => Camera preview is rotated and wrong

Not include all lines in `updatePreviewOrientation`:
- Launch the app in Landscape mode => Camera preview is correct
- Rotate the iPad in any direction => Preview stays correct
