### PR TITLE
Update ScannerView to accept a filter parameter to filter out barcode results before success callback is invoked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 sample/iosApp/iosApp.xcodeproj/*
 !sample/iosApp/iosApp.xcodeproj/project.pbxproj
 gradle.properties
+.kotlin

--- a/kscan/src/androidMain/kotlin/org/ncgroup/kscan/BarcodeAnalyzer.kt
+++ b/kscan/src/androidMain/kotlin/org/ncgroup/kscan/BarcodeAnalyzer.kt
@@ -53,6 +53,7 @@ class BarcodeAnalyzer(
     private val codeTypes: List<BarcodeFormat>,
     private val onSuccess: (List<Barcode>) -> Unit,
     private val onFailed: (Exception) -> Unit,
+    private val filter: (Barcode) -> Boolean,
     private val onCanceled: () -> Unit,
 ) : ImageAnalysis.Analyzer {
     private val scannerOptions =
@@ -126,6 +127,9 @@ class BarcodeAnalyzer(
                         data = displayValue,
                         format = appSpecificFormat.toString(),
                     )
+
+                if (!filter(detectedAppBarcode)) return
+
                 onSuccess(listOf(detectedAppBarcode))
                 barcodesDetected.clear()
                 hasSuccessfullyProcessedBarcode = true

--- a/kscan/src/androidMain/kotlin/org/ncgroup/kscan/ScannerView.android.kt
+++ b/kscan/src/androidMain/kotlin/org/ncgroup/kscan/ScannerView.android.kt
@@ -42,6 +42,7 @@ actual fun ScannerView(
     colors: ScannerColors,
     showUi: Boolean,
     scannerController: ScannerController?,
+    filter: (Barcode) -> Boolean,
     result: (BarcodeResult) -> Unit,
 ) {
     val context = LocalContext.current
@@ -133,6 +134,7 @@ actual fun ScannerView(
                                 },
                                 onFailed = { result(BarcodeResult.OnFailed(Exception(it))) },
                                 onCanceled = { result(BarcodeResult.OnCanceled) },
+                                filter = filter
                             ),
                         )
 

--- a/kscan/src/commonMain/kotlin/org/ncgroup/kscan/ScannerView.kt
+++ b/kscan/src/commonMain/kotlin/org/ncgroup/kscan/ScannerView.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
  * @param colors The colors to be used for the scanner view.
  * @param showUi A boolean indicating whether to show the UI elements of the scanner view.
  * @param scannerController An optional controller for controlling the scanner.
+ * @param filter An optional lambda which can be used to filter out results before receiving a [BarcodeResult]
  * @param result A callback function that is invoked when a barcode is scanned.
  */
 @Composable
@@ -21,5 +22,6 @@ expect fun ScannerView(
     colors: ScannerColors = scannerColors(),
     showUi: Boolean = true,
     scannerController: ScannerController? = null,
+    filter: (Barcode) -> Boolean = { true },
     result: (BarcodeResult) -> Unit,
 )

--- a/kscan/src/iosMain/kotlin/org/ncgroup/kscan/CameraViewController.kt
+++ b/kscan/src/iosMain/kotlin/org/ncgroup/kscan/CameraViewController.kt
@@ -45,6 +45,8 @@ import platform.darwin.dispatch_get_main_queue
  * @property onBarcodeSuccess A callback function that is invoked when barcodes are successfully detected.
  * @property onBarcodeFailed A callback function that is invoked when an error occurs during barcode scanning.
  * @property onBarcodeCanceled A callback function that is invoked when barcode scanning is canceled. (Currently not used within this class)
+ * @property filter A callback function that is invoked when barcode result is processed. [onBarcodeSuccess] will only be invoked
+ * if the invocation of this property resolves to true.
  * @property onMaxZoomRatioAvailable A callback function that is invoked with the maximum available zoom ratio for the camera.
  */
 class CameraViewController(
@@ -53,6 +55,7 @@ class CameraViewController(
     private val onBarcodeSuccess: (List<Barcode>) -> Unit,
     private val onBarcodeFailed: (Exception) -> Unit,
     private val onBarcodeCanceled: () -> Unit,
+    private val filter: (Barcode) -> Boolean,
     private val onMaxZoomRatioAvailable: (Float) -> Unit,
 ) : UIViewController(null, null), AVCaptureMetadataOutputObjectsDelegateProtocol {
     private lateinit var captureSession: AVCaptureSession
@@ -179,6 +182,9 @@ class CameraViewController(
                     data = value,
                     format = appSpecificFormat.toString(),
                 )
+
+            if (!filter(barcode)) return
+
             onBarcodeSuccess(listOf(barcode))
             barcodesDetected.clear()
             if (::captureSession.isInitialized && captureSession.isRunning()) {

--- a/kscan/src/iosMain/kotlin/org/ncgroup/kscan/ScannerView.ios.kt
+++ b/kscan/src/iosMain/kotlin/org/ncgroup/kscan/ScannerView.ios.kt
@@ -29,6 +29,7 @@ actual fun ScannerView(
     colors: ScannerColors,
     showUi: Boolean,
     scannerController: ScannerController?,
+    filter: (Barcode) -> Boolean,
     result: (BarcodeResult) -> Unit,
 ) {
     var torchEnabled by remember { mutableStateOf(false) }
@@ -76,6 +77,7 @@ actual fun ScannerView(
             CameraViewController(
                 device = captureDevice,
                 codeTypes = codeTypes,
+                filter = filter,
                 onBarcodeSuccess = { scannedBarcodes ->
                     result(BarcodeResult.OnSuccess(scannedBarcodes.first()))
                 },
@@ -87,7 +89,7 @@ actual fun ScannerView(
                 },
                 onMaxZoomRatioAvailable = { maxRatio ->
                     maxZoomRatio = maxRatio
-                },
+                }
             )
         }
 


### PR DESCRIPTION
Hello! Our team has been leveraging this library and have a use-case that called for this change. We use the library to scan and identify devices within an inventory, and some of our devices have two different barcodes printed on it. The one that we're actually interested in scanning starts with a specific character sequence, so we would like to make it so we continue scanning until we find a barcode that matches that character sequence. 