### PR TITLE
Add functionality to supply rawBytes to Barcode

### DIFF
--- a/kscan/src/androidMain/kotlin/org/ncgroup/kscan/BarcodeAnalyzer.kt
+++ b/kscan/src/androidMain/kotlin/org/ncgroup/kscan/BarcodeAnalyzer.kt
@@ -118,6 +118,7 @@ class BarcodeAnalyzer(
 
         for (mlKitBarcode in mlKitBarcodes) {
             val displayValue = mlKitBarcode.displayValue ?: continue
+            val rawBytes = mlKitBarcode.rawBytes ?: displayValue.encodeToByteArray()
 
             barcodesDetected[displayValue] = (barcodesDetected[displayValue] ?: 0) + 1
             if ((barcodesDetected[displayValue] ?: 0) >= 2) {
@@ -126,6 +127,7 @@ class BarcodeAnalyzer(
                     Barcode(
                         data = displayValue,
                         format = appSpecificFormat.toString(),
+                        rawBytes = rawBytes,
                     )
 
                 if (!filter(detectedAppBarcode)) return

--- a/kscan/src/commonMain/kotlin/org/ncgroup/kscan/Barcode.kt
+++ b/kscan/src/commonMain/kotlin/org/ncgroup/kscan/Barcode.kt
@@ -3,10 +3,32 @@ package org.ncgroup.kscan
 /**
  * Represents a scanned barcode.
  *
- * @property data The decoded data from the barcode.
+ * @property data The decoded String data from the barcode.
  * @property format The format of the barcode (e.g., QR_CODE, EAN_13).
+ * @property rawBytes The raw byte data from the barcode.
  */
 data class Barcode(
     val data: String,
     val format: String,
-)
+    val rawBytes: ByteArray,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as Barcode
+
+        if (data != other.data) return false
+        if (format != other.format) return false
+        if (!rawBytes.contentEquals(other.rawBytes)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = data.hashCode()
+        result = 31 * result + format.hashCode()
+        result = 31 * result + rawBytes.contentHashCode()
+        return result
+    }
+}

--- a/kscan/src/iosMain/kotlin/org/ncgroup/kscan/CameraViewController.kt
+++ b/kscan/src/iosMain/kotlin/org/ncgroup/kscan/CameraViewController.kt
@@ -181,6 +181,7 @@ class CameraViewController(
                 Barcode(
                     data = value,
                     format = appSpecificFormat.toString(),
+                    rawBytes = value.encodeToByteArray(),
                 )
 
             if (!filter(barcode)) return


### PR DESCRIPTION
This PR adds the `rawBytes` property to `Barcode` which supplies a `ByteArray` representing the raw binary data represented by the Barcode object

For Android, this utilises MLKit's `Barcode.rawBytes` property and for iOS we encode the existing String to a byte array