### PR TITLE
feat: add scannerUIOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ if (showScanner) {
 }
 ```
 
-If you want to remove the UI and just use the raw scanner, you can set the showUi parameter to false
+If you want to remove the UI and just use the raw scanner, you can set the scannerUiOptions parameter to `null`
 
 ```Kotlin
 if (showScanner) {
@@ -124,7 +124,7 @@ if (showScanner) {
             BarcodeFormats.FORMAT_QR_CODE,
             BarcodeFormats.FORMAT_EAN_13,
         ),
-        showUi = false
+        scannerUiOptions = null
     ) { result ->
         when (result) {
             is BarcodeResult.OnSuccess -> {
@@ -143,7 +143,7 @@ if (showScanner) {
 }
 ```
 
-To build a custom scanner UI with torch and zoom control, set showUi = false and use a ScannerController.
+To build a custom scanner UI with torch and zoom control, set `scannerUiOptions = null` and use a ScannerController.
 
 ```Kotlin
 val scannerController = remember { ScannerController() }
@@ -151,7 +151,7 @@ val scannerController = remember { ScannerController() }
 if (showScanner) {
     ScannerView(
         codeTypes = listOf(BarcodeFormat.FORMAT_ALL_FORMATS),
-        showUi = false,
+        scannerUiOptions = null,
         scannerController = scannerController
     ) { result ->
         when (result) {

--- a/kscan/src/androidMain/kotlin/org/ncgroup/kscan/ScannerView.android.kt
+++ b/kscan/src/androidMain/kotlin/org/ncgroup/kscan/ScannerView.android.kt
@@ -27,22 +27,12 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
 
-/**
- * Composable function that displays a camera preview for scanning barcodes.
- *
- * @param modifier The modifier to be applied to the scanner view.
- * @param codeTypes A list of barcode formats to be scanned.
- * @param colors The colors to be used for the scanner UI.
- * @param showUi A boolean indicating whether to show the scanner UI.
- * @param scannerController An optional controller for managing scanner actions.
- * @param result A callback function that receives the barcode scanning result.
- */
 @Composable
 actual fun ScannerView(
     modifier: Modifier,
     codeTypes: List<BarcodeFormat>,
     colors: ScannerColors,
-    showUi: Boolean,
+    scannerUiOptions: ScannerUiOptions?,
     scannerController: ScannerController?,
     filter: (Barcode) -> Boolean,
     result: (BarcodeResult) -> Unit,
@@ -170,7 +160,7 @@ actual fun ScannerView(
             else -> {}
         }
 
-        if (showUi) {
+        if (scannerUiOptions != null) {
             ScannerUI(
                 onCancel = { result(BarcodeResult.OnCanceled) },
                 torchEnabled = torchEnabled,
@@ -179,6 +169,7 @@ actual fun ScannerView(
                 zoomRatioOnChange = { ratio -> cameraControl?.setZoomRatio(ratio) },
                 maxZoomRatio = maxZoomRatio,
                 colors = colors,
+                options = scannerUiOptions,
             )
         }
     }

--- a/kscan/src/commonMain/kotlin/org/ncgroup/kscan/ScannerHeader.kt
+++ b/kscan/src/commonMain/kotlin/org/ncgroup/kscan/ScannerHeader.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.graphics.Color
  *
  * @param modifier The modifier to be applied to the scanner header.
  * @param onCancel A callback function that is invoked when the cancel button is clicked.
+ * @param showTorch A boolean value that determines whether to show the torch button or not.
  * @param torchEnabled A boolean value that indicates whether the torch is enabled.
  * @param onTorchEnabled A callback function that is invoked when the torch toggle button is clicked.
  * @param containerColor The color of the container.
@@ -31,8 +32,10 @@ import androidx.compose.ui.graphics.Color
 internal fun ScannerHeader(
     modifier: Modifier = Modifier,
     onCancel: () -> Unit,
+    showTorch: Boolean,
     torchEnabled: Boolean,
     onTorchEnabled: (Boolean) -> Unit,
+    title: String,
     containerColor: Color = Color(0xFF291544),
     navigationIconColor: Color = Color.White,
     titleColor: Color = Color.White,
@@ -41,7 +44,7 @@ internal fun ScannerHeader(
     CenterAlignedTopAppBar(
         title = {
             Text(
-                text = "Scan Code",
+                text = title,
             )
         },
         navigationIcon = {
@@ -57,19 +60,21 @@ internal fun ScannerHeader(
             }
         },
         actions = {
-            IconButton(
-                onClick = {
-                    if (torchEnabled) {
-                        onTorchEnabled(false)
-                    } else {
-                        onTorchEnabled(true)
-                    }
-                },
-            ) {
-                Icon(
-                    imageVector = if (torchEnabled) Icons.Default.FlashOn else Icons.Default.FlashOff,
-                    contentDescription = null,
-                )
+            if (showTorch) {
+                IconButton(
+                    onClick = {
+                        if (torchEnabled) {
+                            onTorchEnabled(false)
+                        } else {
+                            onTorchEnabled(true)
+                        }
+                    },
+                ) {
+                    Icon(
+                        imageVector = if (torchEnabled) Icons.Default.FlashOn else Icons.Default.FlashOff,
+                        contentDescription = null,
+                    )
+                }
             }
         },
         colors =

--- a/kscan/src/commonMain/kotlin/org/ncgroup/kscan/ScannerUI.kt
+++ b/kscan/src/commonMain/kotlin/org/ncgroup/kscan/ScannerUI.kt
@@ -29,6 +29,7 @@ fun ScannerUI(
     zoomRatioOnChange: (Float) -> Unit,
     maxZoomRatio: Float,
     colors: ScannerColors = scannerColors(),
+    options: ScannerUiOptions = ScannerUiOptions(),
 ) {
     Column(
         modifier = Modifier.fillMaxSize(),
@@ -36,8 +37,10 @@ fun ScannerUI(
     ) {
         ScannerHeader(
             onCancel = onCancel,
+            showTorch = options.showTorch,
             torchEnabled = torchEnabled,
             onTorchEnabled = onTorchEnabled,
+            title = options.headerTitle,
             containerColor = colors.headerContainerColor,
             navigationIconColor = colors.headerNavigationIconColor,
             titleColor = colors.headerTitleColor,
@@ -52,13 +55,15 @@ fun ScannerUI(
 
         Spacer(modifier = Modifier.weight(1f))
 
-        ScannerZoomAdjuster(
-            modifier = Modifier.padding(bottom = 30.dp),
-            zoomRatio = zoomRatio,
-            zoomRatioOnChange = zoomRatioOnChange,
-            maxZoomRatio = maxZoomRatio,
-            containerColor = colors.zoomControllerContainerColor,
-            contentColor = colors.zoomControllerContentColor,
-        )
+        if (options.showZoom) {
+            ScannerZoomAdjuster(
+                modifier = Modifier.padding(bottom = 30.dp),
+                zoomRatio = zoomRatio,
+                zoomRatioOnChange = zoomRatioOnChange,
+                maxZoomRatio = maxZoomRatio,
+                containerColor = colors.zoomControllerContainerColor,
+                contentColor = colors.zoomControllerContentColor,
+            )
+        }
     }
 }

--- a/kscan/src/commonMain/kotlin/org/ncgroup/kscan/ScannerUiOptions.kt
+++ b/kscan/src/commonMain/kotlin/org/ncgroup/kscan/ScannerUiOptions.kt
@@ -1,0 +1,10 @@
+package org.ncgroup.kscan
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+data class ScannerUiOptions(
+    val headerTitle: String = "Scan Code",
+    val showZoom: Boolean = true,
+    val showTorch: Boolean = true,
+)

--- a/kscan/src/commonMain/kotlin/org/ncgroup/kscan/ScannerView.kt
+++ b/kscan/src/commonMain/kotlin/org/ncgroup/kscan/ScannerView.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.Modifier
  * @param modifier The modifier to be applied to the scanner view.
  * @param codeTypes The list of barcode formats to be scanned.
  * @param colors The colors to be used for the scanner view.
- * @param showUi A boolean indicating whether to show the UI elements of the scanner view.
+ * @param scannerUiOptions The UI options to be used for the scanner UI. Will hide the UI if set to `null`.
  * @param scannerController An optional controller for controlling the scanner.
  * @param filter An optional lambda which can be used to filter out results before receiving a [BarcodeResult]
  * @param result A callback function that is invoked when a barcode is scanned.
@@ -20,7 +20,7 @@ expect fun ScannerView(
     modifier: Modifier = Modifier.fillMaxSize(),
     codeTypes: List<BarcodeFormat>,
     colors: ScannerColors = scannerColors(),
-    showUi: Boolean = true,
+    scannerUiOptions: ScannerUiOptions? = ScannerUiOptions(),
     scannerController: ScannerController? = null,
     filter: (Barcode) -> Boolean = { true },
     result: (BarcodeResult) -> Unit,

--- a/kscan/src/iosMain/kotlin/org/ncgroup/kscan/ScannerView.ios.kt
+++ b/kscan/src/iosMain/kotlin/org/ncgroup/kscan/ScannerView.ios.kt
@@ -27,7 +27,7 @@ actual fun ScannerView(
     modifier: Modifier,
     codeTypes: List<BarcodeFormat>,
     colors: ScannerColors,
-    showUi: Boolean,
+    scannerUiOptions: ScannerUiOptions?,
     scannerController: ScannerController?,
     filter: (Barcode) -> Boolean,
     result: (BarcodeResult) -> Unit,
@@ -110,7 +110,7 @@ actual fun ScannerView(
             modifier = Modifier.fillMaxSize(),
         )
 
-        if (showUi) {
+        if (scannerUiOptions != null) {
             ScannerUI(
                 onCancel = {
                     result(BarcodeResult.OnCanceled)
@@ -125,6 +125,7 @@ actual fun ScannerView(
                 },
                 maxZoomRatio = maxZoomRatio,
                 colors = colors,
+                options = scannerUiOptions,
             )
         }
     }

--- a/kscan/src/jvmMain/kotlin/org/ncgroup/kscan/ScannerView.jvm.kt
+++ b/kscan/src/jvmMain/kotlin/org/ncgroup/kscan/ScannerView.jvm.kt
@@ -8,7 +8,7 @@ actual fun ScannerView(
     modifier: Modifier,
     codeTypes: List<BarcodeFormat>,
     colors: ScannerColors,
-    showUi: Boolean,
+    scannerUiOptions: ScannerUiOptions?,
     scannerController: ScannerController?,
     filter: (Barcode) -> Boolean,
     result: (BarcodeResult) -> Unit

--- a/kscan/src/wasmJsMain/kotlin/org/ncgroup/kscan/ScannerView.wasmJs.kt
+++ b/kscan/src/wasmJsMain/kotlin/org/ncgroup/kscan/ScannerView.wasmJs.kt
@@ -8,7 +8,7 @@ actual fun ScannerView(
     modifier: Modifier,
     codeTypes: List<BarcodeFormat>,
     colors: ScannerColors,
-    showUi: Boolean,
+    scannerUiOptions: ScannerUiOptions?,
     scannerController: ScannerController?,
     filter: (Barcode) -> Boolean,
     result: (BarcodeResult) -> Unit

--- a/sample/shared/src/commonMain/kotlin/org/ncgroup/kscan/CustomUI.kt
+++ b/sample/shared/src/commonMain/kotlin/org/ncgroup/kscan/CustomUI.kt
@@ -50,7 +50,7 @@ fun CustomUI(modifier: Modifier = Modifier) {
                         listOf(
                             BarcodeFormat.FORMAT_ALL_FORMATS,
                         ),
-                    showUi = false,
+                    scannerUiOptions = null,
                     scannerController = scannerController,
                 ) { result ->
                     when (result) {


### PR DESCRIPTION
BREAKING CHANGE: removes showUi in favor of scannerUiOptions

this adds a little more customizability. let me know if you think showTorch option is unnecessary and want it removed

in bisq mobile project we have commented out zoom controls, plus we have i18n, which makes the default hardcoded title unfavorable, but it's also unnecessary to create UI from scratch just for that, hence this PR

note: this is just what I think may be an improvement, feel free to discuss and turn down this PR if you think it's not good