### PR TITLE
add ITF format for iOS

### DIFF
--- a/kscan/src/iosMain/kotlin/org/ncgroup/kscan/BarcodeFormatMapper.kt
+++ b/kscan/src/iosMain/kotlin/org/ncgroup/kscan/BarcodeFormatMapper.kt
@@ -8,6 +8,7 @@ import platform.AVFoundation.AVMetadataObjectTypeCode93Code
 import platform.AVFoundation.AVMetadataObjectTypeDataMatrixCode
 import platform.AVFoundation.AVMetadataObjectTypeEAN13Code
 import platform.AVFoundation.AVMetadataObjectTypeEAN8Code
+import platform.AVFoundation.AVMetadataObjectTypeInterleaved2of5Code
 import platform.AVFoundation.AVMetadataObjectTypePDF417Code
 import platform.AVFoundation.AVMetadataObjectTypeQRCode
 import platform.AVFoundation.AVMetadataObjectTypeUPCECode
@@ -28,6 +29,7 @@ internal object BarcodeFormatMapper {
         AVMetadataObjectTypePDF417Code to BarcodeFormat.FORMAT_PDF417,
         AVMetadataObjectTypeAztecCode to BarcodeFormat.FORMAT_AZTEC,
         AVMetadataObjectTypeDataMatrixCode to BarcodeFormat.FORMAT_DATA_MATRIX,
+        AVMetadataObjectTypeInterleaved2of5Code to BarcodeFormat.FORMAT_ITF,
     )
 
     private val APP_TO_AV_FORMAT_MAP: Map<BarcodeFormat, AVMetadataObjectType> =

--- a/kscan/src/iosTest/kotlin/org/ncgroup/kscan/BarcodeFormatMapperTest.kt
+++ b/kscan/src/iosTest/kotlin/org/ncgroup/kscan/BarcodeFormatMapperTest.kt
@@ -2,6 +2,7 @@ package org.ncgroup.kscan
 
 import platform.AVFoundation.AVMetadataObjectTypeCode128Code
 import platform.AVFoundation.AVMetadataObjectTypeEAN13Code
+import platform.AVFoundation.AVMetadataObjectTypeInterleaved2of5Code
 import platform.AVFoundation.AVMetadataObjectTypeQRCode
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -59,6 +60,13 @@ class BarcodeFormatMapperTest {
         val result = BarcodeFormatMapper.toAppFormat(AVMetadataObjectTypeCode128Code)
 
         assertEquals(BarcodeFormat.FORMAT_CODE_128, result)
+    }
+
+    @Test
+    fun `GIVEN interleaved2of5 av type WHEN toAppFormat THEN returns app format`() {
+        val result = BarcodeFormatMapper.toAppFormat(AVMetadataObjectTypeInterleaved2of5Code)
+
+        assertEquals(BarcodeFormat.FORMAT_ITF, result)
     }
 
     @Test


### PR DESCRIPTION
This pull request aims to resolve issue #51 by adding a mapping between `AVMetadataObjectTypeInterleaved2of5Code` and `BarcodeFormat.FORMAT_ITF`.

It was tested on iOS and seems to work. When testing, it is important that the barcode is black (or at least some dark color) since AVFoundation does not seem to support inverted colors for ITF format barcodes (like white barcode on black background).

A test verifying the mapping on iOS was added, if further tests are required please let me know.
