### PR TITLE
Fix iOS QR raw-byte parsing for multi-segment payloads

### DIFF
--- a/kscan/src/iosMain/kotlin/org/ncgroup/kscan/QRCodePayloadParser.kt
+++ b/kscan/src/iosMain/kotlin/org/ncgroup/kscan/QRCodePayloadParser.kt
@@ -10,12 +10,26 @@ import platform.posix.memcpy
 /**
  * Parses raw bytes from CIQRCodeDescriptor.errorCorrectedPayload.
  *
- * Only handles byte mode segments (which can contain null bytes).
- * Returns null for other modes, falling back to stringValue which works fine for them.
+ * Iterates over all QR data segments (byte, alphanumeric, numeric) and concatenates
+ * their decoded content. Byte segments are appended as raw bytes (preserving null
+ * bytes); alphanumeric and numeric segments are decoded per the QR spec and appended
+ * as their ISO-8859-1 bytes.
+ *
+ * Returns a non-null result only when at least one byte segment was present — the
+ * sole reason this parser exists is to preserve null bytes that
+ * AVMetadataMachineReadableCodeObject.stringValue would silently truncate. For
+ * purely alphanumeric/numeric QRs (or Kanji/unknown modes), returns null so the
+ * caller falls back to stringValue.
  */
 internal object QRCodePayloadParser {
 
+    private const val MODE_TERMINATOR = 0
+    private const val MODE_NUMERIC = 1
+    private const val MODE_ALPHANUMERIC = 2
     private const val MODE_BYTE = 4
+
+    private const val ALPHANUMERIC_TABLE =
+        "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ \$%*+-./:"
 
     @OptIn(ExperimentalForeignApi::class)
     fun extractRawBytes(descriptor: CIQRCodeDescriptor): ByteArray? {
@@ -26,35 +40,148 @@ internal object QRCodePayloadParser {
     }
 
     internal fun decodeDataStream(codewords: ByteArray): ByteArray? {
-        // Try both possible byte-mode length sizes:
+        // The byte-mode length field width depends on QR version:
         // - QR versions 1–9  => 8 bits
         // - QR versions 10–40 => 16 bits
-        for (countBits in listOf(8, 16)) {
+        // Alphanumeric/numeric have their own fixed widths per the spec (9/10 bits
+        // for v1-9, which is all we attempt to support here).
+        for (byteCountBits in listOf(8, 16)) {
             val reader = BitReader(codewords)
+            val result = mutableListOf<Byte>()
+            var hadByteSegment = false
+            var aborted = false
 
-            if (!reader.hasAvailable(4)) continue
-            val mode = reader.readBits(4)
+            while (reader.hasAvailable(4)) {
+                val mode = reader.readBits(4)
+                if (mode == MODE_TERMINATOR) break
 
-            // Only handle byte mode - other modes can't have null bytes
-            if (mode != MODE_BYTE) return null
+                when (mode) {
+                    MODE_BYTE -> {
+                        if (!reader.hasAvailable(byteCountBits)) {
+                            aborted = true
+                            break
+                        }
+                        val count = reader.readBits(byteCountBits)
+                        if (count !in 1..4096 || !reader.hasAvailable(count * 8)) {
+                            aborted = true
+                            break
+                        }
+                        hadByteSegment = true
+                        repeat(count) { result.add(reader.readBits(8).toByte()) }
+                    }
 
-            if (!reader.hasAvailable(countBits)) continue
-            val count = reader.readBits(countBits)
+                    MODE_ALPHANUMERIC -> {
+                        if (!reader.hasAvailable(9)) {
+                            aborted = true
+                            break
+                        }
+                        val count = reader.readBits(9)
+                        val sb = StringBuilder()
+                        val pairs = count / 2
+                        val remainder = count % 2
+                        var ok = true
+                        repeat(pairs) {
+                            if (!ok) return@repeat
+                            if (!reader.hasAvailable(11)) {
+                                ok = false
+                                return@repeat
+                            }
+                            val v = reader.readBits(11)
+                            val hi = v / 45
+                            val lo = v % 45
+                            if (hi !in ALPHANUMERIC_TABLE.indices ||
+                                lo !in ALPHANUMERIC_TABLE.indices
+                            ) {
+                                ok = false
+                                return@repeat
+                            }
+                            sb.append(ALPHANUMERIC_TABLE[hi])
+                            sb.append(ALPHANUMERIC_TABLE[lo])
+                        }
+                        if (ok && remainder == 1) {
+                            if (!reader.hasAvailable(6)) {
+                                ok = false
+                            } else {
+                                val v = reader.readBits(6)
+                                if (v !in ALPHANUMERIC_TABLE.indices) {
+                                    ok = false
+                                } else {
+                                    sb.append(ALPHANUMERIC_TABLE[v])
+                                }
+                            }
+                        }
+                        if (!ok) {
+                            aborted = true
+                            break
+                        }
+                        appendIsoLatin1(result, sb.toString())
+                    }
 
-            if (count <= 0) continue
+                    MODE_NUMERIC -> {
+                        if (!reader.hasAvailable(10)) {
+                            aborted = true
+                            break
+                        }
+                        val count = reader.readBits(10)
+                        val sb = StringBuilder()
+                        val triples = count / 3
+                        val rem = count % 3
+                        var ok = true
+                        repeat(triples) {
+                            if (!ok) return@repeat
+                            if (!reader.hasAvailable(10)) {
+                                ok = false
+                                return@repeat
+                            }
+                            sb.append(reader.readBits(10).toString().padStart(3, '0'))
+                        }
+                        if (ok) {
+                            when (rem) {
+                                2 -> if (reader.hasAvailable(7)) {
+                                    sb.append(reader.readBits(7).toString().padStart(2, '0'))
+                                } else {
+                                    ok = false
+                                }
+                                1 -> if (reader.hasAvailable(4)) {
+                                    sb.append(reader.readBits(4).toString())
+                                } else {
+                                    ok = false
+                                }
+                            }
+                        }
+                        if (!ok) {
+                            aborted = true
+                            break
+                        }
+                        appendIsoLatin1(result, sb.toString())
+                    }
 
-            // Optional sanity guard (remove if you prefer)
-            if (count > 4096) continue
-            if (!reader.hasAvailable(count * 8)) continue
-
-            val result = ByteArray(count)
-            repeat(count) { i ->
-                result[i] = reader.readBits(8).toByte()
+                    else -> {
+                        // Kanji, ECI, structured-append, FNC1, or unknown — can't
+                        // safely decode here. Abort this attempt; if the mode was
+                        // caused by trying the wrong byte-count width, the next
+                        // attempt can still succeed. Otherwise we'll fall back to
+                        // stringValue after all attempts fail.
+                        aborted = true
+                        break
+                    }
+                }
             }
-            return result
+
+            if (!aborted && hadByteSegment && result.isNotEmpty()) {
+                return result.toByteArray()
+            }
         }
 
         return null
+    }
+
+    private fun appendIsoLatin1(dest: MutableList<Byte>, s: String) {
+        // ISO-8859-1: each code point 0..0xFF maps to a single byte of the same value.
+        // Alphanumeric/numeric segments only produce ASCII, which is a subset.
+        for (ch in s) {
+            dest.add((ch.code and 0xFF).toByte())
+        }
     }
 
     @OptIn(ExperimentalForeignApi::class)

--- a/kscan/src/iosMain/kotlin/org/ncgroup/kscan/QRCodePayloadParser.kt
+++ b/kscan/src/iosMain/kotlin/org/ncgroup/kscan/QRCodePayloadParser.kt
@@ -39,141 +39,163 @@ internal object QRCodePayloadParser {
         return decodeDataStream(codewords)
     }
 
+    /**
+     * Character-count indicator widths per QR version group (ISO/IEC 18004 Table 3).
+     *
+     * Within a single QR symbol all segments share the same version, so all three
+     * widths must come from the same row. We try each row in turn; the first one
+     * that decodes cleanly and contains at least one byte segment wins.
+     */
+    private data class VersionWidths(
+        val byteCount: Int,
+        val alphaCount: Int,
+        val numericCount: Int,
+    )
+
+    private val VERSION_GROUPS = listOf(
+        VersionWidths(byteCount = 8, alphaCount = 9, numericCount = 10),   // v1–9
+        VersionWidths(byteCount = 16, alphaCount = 11, numericCount = 12), // v10–26
+        VersionWidths(byteCount = 16, alphaCount = 13, numericCount = 14), // v27–40
+    )
+
     internal fun decodeDataStream(codewords: ByteArray): ByteArray? {
-        // The byte-mode length field width depends on QR version:
-        // - QR versions 1–9  => 8 bits
-        // - QR versions 10–40 => 16 bits
-        // Alphanumeric/numeric have their own fixed widths per the spec (9/10 bits
-        // for v1-9, which is all we attempt to support here).
-        for (byteCountBits in listOf(8, 16)) {
-            val reader = BitReader(codewords)
-            val result = mutableListOf<Byte>()
-            var hadByteSegment = false
-            var aborted = false
+        for (widths in VERSION_GROUPS) {
+            val result = tryDecodeWithWidths(codewords, widths)
+            if (result != null) return result
+        }
+        return null
+    }
 
-            while (reader.hasAvailable(4)) {
-                val mode = reader.readBits(4)
-                if (mode == MODE_TERMINATOR) break
+    private fun tryDecodeWithWidths(
+        codewords: ByteArray,
+        widths: VersionWidths,
+    ): ByteArray? {
+        val reader = BitReader(codewords)
+        val result = mutableListOf<Byte>()
+        var hadByteSegment = false
+        var aborted = false
 
-                when (mode) {
-                    MODE_BYTE -> {
-                        if (!reader.hasAvailable(byteCountBits)) {
-                            aborted = true
-                            break
-                        }
-                        val count = reader.readBits(byteCountBits)
-                        if (count !in 1..4096 || !reader.hasAvailable(count * 8)) {
-                            aborted = true
-                            break
-                        }
-                        hadByteSegment = true
-                        repeat(count) { result.add(reader.readBits(8).toByte()) }
-                    }
+        while (reader.hasAvailable(4)) {
+            val mode = reader.readBits(4)
+            if (mode == MODE_TERMINATOR) break
 
-                    MODE_ALPHANUMERIC -> {
-                        if (!reader.hasAvailable(9)) {
-                            aborted = true
-                            break
-                        }
-                        val count = reader.readBits(9)
-                        val sb = StringBuilder()
-                        val pairs = count / 2
-                        val remainder = count % 2
-                        var ok = true
-                        repeat(pairs) {
-                            if (!ok) return@repeat
-                            if (!reader.hasAvailable(11)) {
-                                ok = false
-                                return@repeat
-                            }
-                            val v = reader.readBits(11)
-                            val hi = v / 45
-                            val lo = v % 45
-                            if (hi !in ALPHANUMERIC_TABLE.indices ||
-                                lo !in ALPHANUMERIC_TABLE.indices
-                            ) {
-                                ok = false
-                                return@repeat
-                            }
-                            sb.append(ALPHANUMERIC_TABLE[hi])
-                            sb.append(ALPHANUMERIC_TABLE[lo])
-                        }
-                        if (ok && remainder == 1) {
-                            if (!reader.hasAvailable(6)) {
-                                ok = false
-                            } else {
-                                val v = reader.readBits(6)
-                                if (v !in ALPHANUMERIC_TABLE.indices) {
-                                    ok = false
-                                } else {
-                                    sb.append(ALPHANUMERIC_TABLE[v])
-                                }
-                            }
-                        }
-                        if (!ok) {
-                            aborted = true
-                            break
-                        }
-                        appendIsoLatin1(result, sb.toString())
-                    }
-
-                    MODE_NUMERIC -> {
-                        if (!reader.hasAvailable(10)) {
-                            aborted = true
-                            break
-                        }
-                        val count = reader.readBits(10)
-                        val sb = StringBuilder()
-                        val triples = count / 3
-                        val rem = count % 3
-                        var ok = true
-                        repeat(triples) {
-                            if (!ok) return@repeat
-                            if (!reader.hasAvailable(10)) {
-                                ok = false
-                                return@repeat
-                            }
-                            sb.append(reader.readBits(10).toString().padStart(3, '0'))
-                        }
-                        if (ok) {
-                            when (rem) {
-                                2 -> if (reader.hasAvailable(7)) {
-                                    sb.append(reader.readBits(7).toString().padStart(2, '0'))
-                                } else {
-                                    ok = false
-                                }
-                                1 -> if (reader.hasAvailable(4)) {
-                                    sb.append(reader.readBits(4).toString())
-                                } else {
-                                    ok = false
-                                }
-                            }
-                        }
-                        if (!ok) {
-                            aborted = true
-                            break
-                        }
-                        appendIsoLatin1(result, sb.toString())
-                    }
-
-                    else -> {
-                        // Kanji, ECI, structured-append, FNC1, or unknown — can't
-                        // safely decode here. Abort this attempt; if the mode was
-                        // caused by trying the wrong byte-count width, the next
-                        // attempt can still succeed. Otherwise we'll fall back to
-                        // stringValue after all attempts fail.
+            when (mode) {
+                MODE_BYTE -> {
+                    if (!reader.hasAvailable(widths.byteCount)) {
                         aborted = true
                         break
                     }
+                    val count = reader.readBits(widths.byteCount)
+                    if (count !in 1..4096 || !reader.hasAvailable(count * 8)) {
+                        aborted = true
+                        break
+                    }
+                    hadByteSegment = true
+                    repeat(count) { result.add(reader.readBits(8).toByte()) }
                 }
-            }
 
-            if (!aborted && hadByteSegment && result.isNotEmpty()) {
-                return result.toByteArray()
+                MODE_ALPHANUMERIC -> {
+                    if (!reader.hasAvailable(widths.alphaCount)) {
+                        aborted = true
+                        break
+                    }
+                    val count = reader.readBits(widths.alphaCount)
+                    val decoded = decodeAlphanumeric(reader, count)
+                    if (decoded == null) {
+                        aborted = true
+                        break
+                    }
+                    appendIsoLatin1(result, decoded)
+                }
+
+                MODE_NUMERIC -> {
+                    if (!reader.hasAvailable(widths.numericCount)) {
+                        aborted = true
+                        break
+                    }
+                    val count = reader.readBits(widths.numericCount)
+                    val decoded = decodeNumeric(reader, count)
+                    if (decoded == null) {
+                        aborted = true
+                        break
+                    }
+                    appendIsoLatin1(result, decoded)
+                }
+
+                else -> {
+                    // Kanji, ECI, structured-append, FNC1, or unknown — can't
+                    // safely decode here. Abort this attempt; the next version
+                    // group may still succeed. If all attempts fail we return
+                    // null and the caller falls back to stringValue.
+                    aborted = true
+                    break
+                }
             }
         }
 
-        return null
+        return if (!aborted && hadByteSegment && result.isNotEmpty()) {
+            result.toByteArray()
+        } else {
+            null
+        }
+    }
+
+    private fun decodeAlphanumeric(reader: BitReader, count: Int): String? {
+        if (count < 0) return null
+        val sb = StringBuilder(count)
+        val pairs = count / 2
+        val remainder = count % 2
+        repeat(pairs) {
+            if (!reader.hasAvailable(11)) return null
+            val v = reader.readBits(11)
+            val hi = v / 45
+            val lo = v % 45
+            if (hi !in ALPHANUMERIC_TABLE.indices ||
+                lo !in ALPHANUMERIC_TABLE.indices
+            ) {
+                return null
+            }
+            sb.append(ALPHANUMERIC_TABLE[hi])
+            sb.append(ALPHANUMERIC_TABLE[lo])
+        }
+        if (remainder == 1) {
+            if (!reader.hasAvailable(6)) return null
+            val v = reader.readBits(6)
+            if (v !in ALPHANUMERIC_TABLE.indices) return null
+            sb.append(ALPHANUMERIC_TABLE[v])
+        }
+        return sb.toString()
+    }
+
+    private fun decodeNumeric(reader: BitReader, count: Int): String? {
+        if (count < 0) return null
+        val sb = StringBuilder(count)
+        val triples = count / 3
+        val rem = count % 3
+        repeat(triples) {
+            if (!reader.hasAvailable(10)) return null
+            val value = reader.readBits(10)
+            // QR spec: each 10-bit group encodes exactly 0..999.
+            if (value > 999) return null
+            sb.append(value.toString().padStart(3, '0'))
+        }
+        when (rem) {
+            2 -> {
+                if (!reader.hasAvailable(7)) return null
+                val value = reader.readBits(7)
+                // QR spec: 7-bit tail encodes exactly 0..99.
+                if (value > 99) return null
+                sb.append(value.toString().padStart(2, '0'))
+            }
+            1 -> {
+                if (!reader.hasAvailable(4)) return null
+                val value = reader.readBits(4)
+                // QR spec: 4-bit tail encodes exactly 0..9.
+                if (value > 9) return null
+                sb.append(value.toString())
+            }
+        }
+        return sb.toString()
     }
 
     private fun appendIsoLatin1(dest: MutableList<Byte>, s: String) {

--- a/kscan/src/iosTest/kotlin/org/ncgroup/kscan/QRCodePayloadParserTest.kt
+++ b/kscan/src/iosTest/kotlin/org/ncgroup/kscan/QRCodePayloadParserTest.kt
@@ -74,12 +74,155 @@ class QRCodePayloadParserTest {
         assertEquals('d'.code.toByte(), result[10])
     }
 
+    @Test
+    fun `GIVEN byte then alphanumeric segments WHEN decodeDataStream THEN concatenated`() {
+        // Real-world pattern: byte segment with a URL prefix (lowercase requires byte
+        // mode) + alphanumeric segment with an uppercase serial (cheaper in
+        // alphanumeric mode).
+        val url = "https://example.com/item?sn="
+        val serial = "ABC123-240101-001"
+        val payload = buildMultiSegmentPayload(
+            listOf(
+                Segment.Byte(url.encodeToByteArray()),
+                Segment.Alphanumeric(serial),
+            ),
+        )
+
+        val result = QRCodePayloadParser.decodeDataStream(payload)
+
+        assertNotNull(result)
+        assertEquals(url + serial, result.decodeToString())
+    }
+
+    @Test
+    fun `GIVEN byte mode payload with 16-bit count WHEN decodeDataStream THEN retries and decodes`() {
+        val data = "QR v10+ byte segment".encodeToByteArray()
+        val payload = buildByteModePayload(data, countBits = 16)
+
+        val result = QRCodePayloadParser.decodeDataStream(payload)
+
+        assertNotNull(result)
+        assertContentEquals(data, result)
+    }
+
+    @Test
+    fun `GIVEN byte then numeric segments WHEN decodeDataStream THEN concatenated`() {
+        val prefix = "ID:"
+        val digits = "1234567" // exercises triples + remainder=1 (4-bit tail)
+        val payload = buildMultiSegmentPayload(
+            listOf(
+                Segment.Byte(prefix.encodeToByteArray()),
+                Segment.Numeric(digits),
+            ),
+        )
+
+        val result = QRCodePayloadParser.decodeDataStream(payload)
+
+        assertNotNull(result)
+        assertEquals(prefix + digits, result.decodeToString())
+    }
+
+    @Test
+    fun `GIVEN byte numeric remainder 2 WHEN decodeDataStream THEN concatenated`() {
+        // remainder=2 exercises the 7-bit numeric tail.
+        val payload = buildMultiSegmentPayload(
+            listOf(
+                Segment.Byte("X".encodeToByteArray()),
+                Segment.Numeric("12345"),
+            ),
+        )
+
+        val result = QRCodePayloadParser.decodeDataStream(payload)
+
+        assertNotNull(result)
+        assertEquals("X12345", result.decodeToString())
+    }
+
+    @Test
+    fun `GIVEN alphanumeric with odd length WHEN decodeDataStream alongside byte THEN concatenated`() {
+        // "ABC" => one 11-bit pair + one 6-bit trailing char.
+        val payload = buildMultiSegmentPayload(
+            listOf(
+                Segment.Byte("u=".encodeToByteArray()),
+                Segment.Alphanumeric("ABC"),
+            ),
+        )
+
+        val result = QRCodePayloadParser.decodeDataStream(payload)
+
+        assertNotNull(result)
+        assertEquals("u=ABC", result.decodeToString())
+    }
+
+    @Test
+    fun `GIVEN kanji mode WHEN decodeDataStream THEN returns null`() {
+        // Mode 1000 (8) = Kanji. The branch should bail out unconditionally.
+        val bits = mutableListOf<Int>()
+        bits.addAll(listOf(1, 0, 0, 0)) // Kanji mode
+        addBits(bits, 1, 8) // a plausible count field; never read
+        bits.addAll(listOf(0, 0, 0, 0))
+        val payload = packBits(bits)
+
+        assertNull(QRCodePayloadParser.decodeDataStream(payload))
+    }
+
     // region Helpers
 
-    private fun buildByteModePayload(data: ByteArray): ByteArray {
+    private sealed class Segment {
+        class Byte(val data: ByteArray) : Segment()
+        class Alphanumeric(val text: String) : Segment()
+        class Numeric(val digits: String) : Segment()
+    }
+
+    private fun buildMultiSegmentPayload(segments: List<Segment>): ByteArray {
+        val bits = mutableListOf<Int>()
+        for (seg in segments) {
+            when (seg) {
+                is Segment.Byte -> {
+                    bits.addAll(listOf(0, 1, 0, 0)) // Mode: 0100
+                    addBits(bits, seg.data.size, 8)
+                    seg.data.forEach { addBits(bits, it.toInt() and 0xFF, 8) }
+                }
+                is Segment.Alphanumeric -> {
+                    val chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ \$%*+-./:"
+                    bits.addAll(listOf(0, 0, 1, 0)) // Mode: 0010
+                    addBits(bits, seg.text.length, 9)
+                    var i = 0
+                    while (i + 2 <= seg.text.length) {
+                        addBits(
+                            bits,
+                            chars.indexOf(seg.text[i]) * 45 + chars.indexOf(seg.text[i + 1]),
+                            11,
+                        )
+                        i += 2
+                    }
+                    if (seg.text.length - i == 1) {
+                        addBits(bits, chars.indexOf(seg.text[i]), 6)
+                    }
+                }
+                is Segment.Numeric -> {
+                    bits.addAll(listOf(0, 0, 0, 1)) // Mode: 0001
+                    addBits(bits, seg.digits.length, 10)
+                    var i = 0
+                    while (i + 3 <= seg.digits.length) {
+                        addBits(bits, seg.digits.substring(i, i + 3).toInt(), 10)
+                        i += 3
+                    }
+                    when (seg.digits.length - i) {
+                        2 -> addBits(bits, seg.digits.substring(i).toInt(), 7)
+                        1 -> addBits(bits, seg.digits.substring(i).toInt(), 4)
+                    }
+                }
+            }
+        }
+        bits.addAll(listOf(0, 0, 0, 0)) // Terminator
+        return packBits(bits)
+    }
+
+    private fun buildByteModePayload(data: ByteArray, countBits: Int = 8): ByteArray {
         val bits = mutableListOf<Int>()
         bits.addAll(listOf(0, 1, 0, 0)) // Mode: 0100 (byte)
-        addBits(bits, data.size, 8)
+        addBits(bits, data.size, countBits)
         data.forEach { addBits(bits, it.toInt() and 0xFF, 8) }
         bits.addAll(listOf(0, 0, 0, 0)) // Terminator
         return packBits(bits)

--- a/kscan/src/iosTest/kotlin/org/ncgroup/kscan/QRCodePayloadParserTest.kt
+++ b/kscan/src/iosTest/kotlin/org/ncgroup/kscan/QRCodePayloadParserTest.kt
@@ -155,6 +155,44 @@ class QRCodePayloadParserTest {
     }
 
     @Test
+    fun `GIVEN 16-bit byte then alphanumeric segments WHEN decodeDataStream THEN concatenated`() {
+        // QR v10-26 uses 16-bit byte count and 11-bit alphanumeric count. Both
+        // widths must come from the same version group — this guards against
+        // mixing widths from different groups when retrying.
+        val prefix = "https://example.com/i/"
+        val suffix = "ABC123-240101"
+        val payload = buildMultiSegmentPayload(
+            listOf(
+                Segment.Byte(prefix.encodeToByteArray(), countBits = 16),
+                Segment.Alphanumeric(suffix, countBits = 11),
+            ),
+        )
+
+        val result = QRCodePayloadParser.decodeDataStream(payload)
+
+        assertNotNull(result)
+        assertEquals(prefix + suffix, result.decodeToString())
+    }
+
+    @Test
+    fun `GIVEN 16-bit byte then numeric segments WHEN decodeDataStream THEN concatenated`() {
+        // QR v10-26 uses 16-bit byte count and 12-bit numeric count.
+        val prefix = "ref="
+        val digits = "987654321"
+        val payload = buildMultiSegmentPayload(
+            listOf(
+                Segment.Byte(prefix.encodeToByteArray(), countBits = 16),
+                Segment.Numeric(digits, countBits = 12),
+            ),
+        )
+
+        val result = QRCodePayloadParser.decodeDataStream(payload)
+
+        assertNotNull(result)
+        assertEquals(prefix + digits, result.decodeToString())
+    }
+
+    @Test
     fun `GIVEN kanji mode WHEN decodeDataStream THEN returns null`() {
         // Mode 1000 (8) = Kanji. The branch should bail out unconditionally.
         val bits = mutableListOf<Int>()
@@ -169,9 +207,9 @@ class QRCodePayloadParserTest {
     // region Helpers
 
     private sealed class Segment {
-        class Byte(val data: ByteArray) : Segment()
-        class Alphanumeric(val text: String) : Segment()
-        class Numeric(val digits: String) : Segment()
+        class Byte(val data: ByteArray, val countBits: Int = 8) : Segment()
+        class Alphanumeric(val text: String, val countBits: Int = 9) : Segment()
+        class Numeric(val digits: String, val countBits: Int = 10) : Segment()
     }
 
     private fun buildMultiSegmentPayload(segments: List<Segment>): ByteArray {
@@ -180,13 +218,13 @@ class QRCodePayloadParserTest {
             when (seg) {
                 is Segment.Byte -> {
                     bits.addAll(listOf(0, 1, 0, 0)) // Mode: 0100
-                    addBits(bits, seg.data.size, 8)
+                    addBits(bits, seg.data.size, seg.countBits)
                     seg.data.forEach { addBits(bits, it.toInt() and 0xFF, 8) }
                 }
                 is Segment.Alphanumeric -> {
                     val chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ \$%*+-./:"
                     bits.addAll(listOf(0, 0, 1, 0)) // Mode: 0010
-                    addBits(bits, seg.text.length, 9)
+                    addBits(bits, seg.text.length, seg.countBits)
                     var i = 0
                     while (i + 2 <= seg.text.length) {
                         addBits(
@@ -202,7 +240,7 @@ class QRCodePayloadParserTest {
                 }
                 is Segment.Numeric -> {
                     bits.addAll(listOf(0, 0, 0, 1)) // Mode: 0001
-                    addBits(bits, seg.digits.length, 10)
+                    addBits(bits, seg.digits.length, seg.countBits)
                     var i = 0
                     while (i + 3 <= seg.digits.length) {
                         addBits(bits, seg.digits.substring(i, i + 3).toInt(), 10)


### PR DESCRIPTION
QRCodePayloadParser previously decoded only the first QR segment and only accepted byte mode. This caused mixed-mode QR codes to lose data after the initial byte segment, because later alphanumeric or numeric segments were never read.

This updates the iOS QR payload parser to iterate through the QR data stream until the terminator, handling:
- byte segments as raw bytes, preserving null bytes
- alphanumeric segments using the QR alphanumeric character table
- numeric segments using QR numeric group decoding
- unsupported modes by falling back to AVFoundation stringValue

The parser still only returns a non-null raw-byte result when at least one byte segment is present. Pure numeric/alphanumeric QR codes continue to fall back to stringValue, since there are no null bytes to preserve and AVFoundation already handles those cases correctly.

The byte-mode length-width retry remains in place for QR version differences (8-bit count for v1-9, 16-bit count for v10-40). Unsupported/unknown modes now abort the current parsing attempt rather than immediately returning null, so the 16-bit retry can still succeed when the first attempt used the wrong byte-count width.

Tests were added for:
- byte + alphanumeric multi-segment QR payloads
- byte + numeric multi-segment QR payloads
- odd-length alphanumeric tails
- numeric remainder decoding
- 16-bit byte-mode count retry
- unsupported Kanji mode fallback

This fixes truncated iOS QR results for mixed-mode QR codes while preserving the existing null-byte-safe behavior introduced for binary QR payloads.